### PR TITLE
Improve mobile word tap handling

### DIFF
--- a/src/game/word-field.js
+++ b/src/game/word-field.js
@@ -61,10 +61,28 @@ export class WordField {
       removing: false,
     };
 
-    element.addEventListener('click', () => {
+    let pointerHandled = false;
+    const select = () => {
       if (word.removing) return;
       const result = this.onSelect(text, data, element);
       if (result.correct) this.#collect(word);
+    };
+
+    element.addEventListener('pointerdown', (event) => {
+      event.preventDefault();
+      pointerHandled = true;
+      window.setTimeout(() => {
+        pointerHandled = false;
+      }, 400);
+      select();
+    });
+    element.addEventListener('click', () => {
+      if (pointerHandled) {
+        pointerHandled = false;
+        return;
+      }
+
+      select();
     });
 
     this.#words.add(word);

--- a/src/styles.css
+++ b/src/styles.css
@@ -243,7 +243,14 @@ body {
     2px 3px 3px rgb(0 0 0 / 55%);
   white-space: nowrap;
   cursor: pointer;
+  touch-action: none;
   will-change: transform;
+}
+
+.floating-word::before {
+  position: absolute;
+  inset: -0.65rem -0.75rem;
+  content: "";
 }
 
 .floating-word:disabled {
@@ -251,7 +258,8 @@ body {
 }
 
 .floating-word--collected {
-  animation: collect-word 360ms ease-out forwards;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .play-screen--mistake {
@@ -451,10 +459,6 @@ body {
 @keyframes logo-in {
   from { opacity: 0; transform: scale(0.85) rotate(-2deg); }
   to { opacity: 1; transform: scale(1) rotate(0); }
-}
-
-@keyframes collect-word {
-  to { opacity: 0; scale: 1.7; filter: blur(0.2rem); }
 }
 
 @keyframes mistake {


### PR DESCRIPTION
### Motivation
- Mobile taps sometimes required multiple taps and felt sluggish, and correct words remained visible and sank after the diamond burst instead of disappearing immediately.
- Increasing the effective touch target and responding to the earlier pointer event should make selection feel more responsive on touch devices.

### Description
- Switch floating-word activation to handle `pointerdown` (with `event.preventDefault()`) and keep a `click` fallback to preserve keyboard/accessibility activation while preventing duplicate handling via a `pointerHandled` flag and timeout in `src/game/word-field.js`.
- Expand the practical touch target by adding an invisible `::before` pseudo-element around `.floating-word` and disable default touch gestures on the word with `touch-action: none` in `src/styles.css`.
- Make collected words disappear immediately by setting `.floating-word--collected` to `opacity: 0` and `pointer-events: none` instead of the previous collect animation, and remove the now-unused `collect-word` keyframes in `src/styles.css`.

### Testing
- Ran `node --check src/game/word-field.js` and it completed successfully.
- Ran `git diff --check` and it completed successfully.
- Attempted `npm run test` but it could not run because `vitest` is not installed in the current environment (missing in `node_modules`).
- Attempted `npm run lint` but it could not run because the local ESLint installation is incomplete/missing expected files in `node_modules`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a1949d188333aa595a15cfe7aced)