### PR TITLE
Add social metadata and refreshed favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Touchwords icon">
+  <defs>
+    <linearGradient id="bg" x1="8" y1="4" x2="56" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#35d0ff" />
+      <stop offset="1" stop-color="#10223d" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <path d="M16 19h32v9H37v24H27V28H16z" fill="#fff8d6" />
+  <circle cx="48" cy="46" r="7" fill="#ffcf4a" stroke="#10223d" stroke-width="4" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,26 @@
       content="A game to help learners identify mistakes in simple past-tense verbs."
     />
     <meta name="theme-color" content="#10223d" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Touchwords" />
+    <meta
+      property="og:description"
+      content="Practise irregular past-tense verbs by spotting the words that need correcting."
+    />
+    <meta property="og:image" content="/assets/images/touchwords-screenshot.png" />
+    <meta
+      property="og:image:alt"
+      content="Touchwords gameplay showing words floating over a colorful island scene."
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Touchwords" />
+    <meta
+      name="twitter:description"
+      content="Practise irregular past-tense verbs by spotting the words that need correcting."
+    />
+    <meta name="twitter:image" content="/assets/images/touchwords-screenshot.png" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="alternate icon" href="/favicon.ico" sizes="any" />
     <title>Touchwords</title>
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Improve social sharing previews so links to the site render a descriptive title, summary and large image preview.
- Replace the existing, hard-to-read favicon with a higher-contrast SVG while retaining the ICO as a fallback for compatibility.

### Description
- Add Open Graph tags (`og:type`, `og:title`, `og:description`, `og:image`, `og:image:alt`) and Twitter card tags (`twitter:*`) to `index.html` to provide richer link previews using the existing gameplay screenshot at `/assets/images/touchwords-screenshot.png`.
- Add a new high-contrast `favicon.svg` and update `index.html` to use it as the primary icon with `rel="icon" type="image/svg+xml"` while keeping `favicon.ico` as an alternate fallback.
- Minor HTML change in `index.html` to insert the new meta tags and favicon links.

### Testing
- Ran `git diff --check`, which passed.
- Ran `npm ci`, which failed because the lockfile is out of sync and reported missing `@napi-rs/wasm-runtime` metadata.
- Ran `npm run lint`, which failed because local dev dependencies (including `eslint`) are not installed/resolvable in the environment.
- Ran `npm test` and `npm run build`, which both failed because `vitest` and `vite` are not available in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b53a88148333a75203a6187ecd1d)